### PR TITLE
k8sでFinansuをデプロイするためのマニフェストを作成

### DIFF
--- a/server/kubernetes/finansu.yml
+++ b/server/kubernetes/finansu.yml
@@ -65,7 +65,7 @@ spec:
           image: nutfes/finansu-view:latest
           resources:
             limits:
-              memory: "128Mi"
+              memory: "512Mi"
               cpu: "500m"
           ports:
             - containerPort: 3000
@@ -82,26 +82,27 @@ spec:
   selector:
     app: finansu-view
 ---
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: finansu-view-ingress
+  name: nginx-deployment
   namespace: finansu
-  labels:
-    name: finansu-view-ingress
 spec:
-  rules:
-  - host: finansu.nutfes.net
-    http:
-      paths:
-      - pathType: Prefix
-        path: "/"
-        backend:
-          service:
-            name: finansu-view-service
-            port: 
-              number: 3000
-  - host: finansu-api.nutfes.net
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+  - host: finansu-api-test.nutfes.net
     http:
       paths:
       - pathType: Prefix
@@ -109,5 +110,5 @@ spec:
         backend:
           service:
             name: finansu-api-service
-            port: 
+            port:
               number: 1323

--- a/server/kubernetes/finansu.yml
+++ b/server/kubernetes/finansu.yml
@@ -82,26 +82,26 @@ spec:
   selector:
     app: finansu-view
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: nginx-deployment
+  name: finansu-ingress
   namespace: finansu
+  labels:
+    name: finansu-ingress
 spec:
-  selector:
-    matchLabels:
-      app: nginx
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        app: nginx
-    spec:
-      containers:
-      - name: nginx
-        image: nginx:1.14.2
-        ports:
-        - containerPort: 80
+  ingressClassName: "nginx"
+  rules:
+  - host: finansu-test.nutfes.net
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: finansu-view-service
+            port:
+              number: 3000
   - host: finansu-api-test.nutfes.net
     http:
       paths:

--- a/server/kubernetes/metalLB/ip-address-pool.yml
+++ b/server/kubernetes/metalLB/ip-address-pool.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 133.125.44.106-133.125.44.106


### PR DESCRIPTION
## 開発背景
finansuをk8sでデプロイするため

## このタスクでやったこと
- MetalLBのinstall
- MetalLBのipアドレスプールを設定するための設定マニフェストの作成
- finansu.ymlを上記に合わせて設定を変更した

## 具体的にやったこと
MetalLBのinstallの参考サイト
https://metallb.universe.tf/installation/
https://www.adaltas.com/en/2022/09/08/kubernetes-metallb-nginx/

## MetalLBのinstall方法
```
kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/namespace.yaml
kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.12.1/manifests/metallb.yaml
```

## IPアドレスプールの設定マニフェスト
MeatalLBをinstalしたら、IPアドレスプールを設定する必要がある。 42b776617fa66efc17362fea3dd5832faa7014ca
133.XXX.XX.XXX-133.XXX.XX.XXXはサクラvpsのIPアドレスを設定
```
apiVersion: v1
kind: ConfigMap
metadata:
  namespace: metallb-system
  name: config
data:
  config: |
    address-pools:
    - name: default
      protocol: layer2
      addresses:
      - 133.XXX.XX.XXX-133.XXX.XX.XXX

```

## Nginx-Ingressの削除とinstall
MetalLBをinstallした場合は、Nginx-Ingrssをreinstallする必要がある。

削除
```
kubectl delete namespaces ingress-nginx
```

install
```
kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.4/deploy/static/provider/cloud/deploy.yaml
```

## finansu.ymlの修正 93c1289780052bf53edf191ddeeb499aaa297415
frontに割り当てるmemoryを512Miに変更
128Miだと立ち上げてもアクセスできなかった。

## 確認事項
- [ ] http://finansu-test.nutfes.net/ にアクセス可能か
- [ ] http://finansu-api-test.nutfes.net/ にアクセス可能か

## 現状できないこと
- node`ik1-440-52102`(サクラserver)以外のnodeにサービスがあると、アクセスできない
- フロント側がAPIとアクセスできない(imageのbuildを修正する必要あり)