### PR TITLE
k8sでGroup-Manager-2をデプロイするためのマニフェストを作成

### DIFF
--- a/server/kubernetes/gm2.yml
+++ b/server/kubernetes/gm2.yml
@@ -1,0 +1,113 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: group-manager-2
+  labels:
+    name: group-manager-2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: group-manager-2-api-deployment
+  namespace: group-manager-2
+spec:
+  selector:
+    matchLabels:
+      app: group-manager-2-api
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: group-manager-2-api
+    spec:
+      containers:
+      - name: group-manager-2-api-container
+        image: nutfes/group-manager-2-api:latest
+        resources:
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 1323
+        envFrom:
+        - configMapRef:
+            name: env-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: group-manager-2-api-service
+  namespace: group-manager-2
+spec:
+  type: NodePort
+  ports:
+  - port: 1323
+  selector:
+    app: group-manager-2-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: group-manager-2-view-deployment
+  namespace: group-manager-2
+spec:
+  selector:
+    matchLabels:
+      app: group-manager-2-view
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: group-manager-2-view
+    spec:
+      containers:
+        - name: group-manager-2-view-container
+          image: nutfes/group-manager-2-admin_view:latest
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          ports:
+            - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata: 
+  name: group-manager-2-view-service
+  namespace: group-manager-2
+spec:
+  type: NodePort
+  ports:
+    - port: 8000
+  selector:
+    app: group-manager-2-view
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: group-manager-2-view-ingress
+  namespace: group-manager-2
+  labels:
+    name: group-manager-2-view-ingress
+spec:
+  rules:
+  - host: group-manager-2.nutfes.net
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: group-manager-2-view-service
+            port: 
+              number: 8000
+  - host: group-manager-2-api.nutfes.net
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: group-manager-2-api-service
+            port: 
+              number: 1323

--- a/server/kubernetes/gm2.yml
+++ b/server/kubernetes/gm2.yml
@@ -25,13 +25,15 @@ spec:
         image: nutfes/group-manager-2-api:latest
         resources:
           limits:
-            memory: "512Mi"
+            memory: "128Mi"
             cpu: "500m"
         ports:
         - containerPort: 1323
         envFrom:
         - configMapRef:
             name: env-config
+        - secretRef:
+            name: secret-data
 ---
 apiVersion: v1
 kind: Service
@@ -65,7 +67,7 @@ spec:
           image: nutfes/group-manager-2-admin_view:latest
           resources:
             limits:
-              memory: "512Mi"
+              memory: "128Mi"
               cpu: "500m"
           ports:
             - containerPort: 8000


### PR DESCRIPTION
# 開発背景
Group-Manager-2をk8sでデプロイするため

# このタスクでやったこと
- [nutfes/group-manager-2-api](https://hub.docker.com/repository/docker/nutfes/group-manager-2-api/general) のコンテナを使用
- ENVファイルの設定はConfigMapを作成
- ENVファイルのパスワードやはトークンはSecretを作成
- Kubernetesにデプロイするマニフェストを作成

# 具体的にやったこと
## ConfigMapの作成
[9dd3e11766ac9e2a3649fc05836cfca2f3dd43f7](https://github.com/NUTFes/settings/commit/9dd3e11766ac9e2a3649fc05836cfca2f3dd43f7)
## Secretの作成
[de1426daf08d8eba6505386351777c24898502c8](https://github.com/NUTFes/settings/commit/de1426daf08d8eba6505386351777c24898502c8)
## マニフェストの作成
2d4ea0833a0b4d289cae4739ffa27620df543d8d
6cb67302f33bbe0f678a82de7b518b5363f43c09

# 確認事項
以下のコマンドを実行して、localhost:9000に接続できるのを確認する。
```
kubectl port-forward -n group-manager-2 services/group-manager-2-view-service 9000:8000
```

# issues
Closed #22 
Closed #21 